### PR TITLE
use righthand hash tag instead of lefthand hash tag

### DIFF
--- a/keyslot.py
+++ b/keyslot.py
@@ -13,7 +13,7 @@ requests.urllib3.disable_warnings()
 def find_slot(args) -> dict:
     key = args.key
     if key.find('{') >= 0:
-        hash_tag = key[key.find('{') + 1 : key.find('}')]
+        hash_tag = key[key.rfind('{') + 1 : key.rfind('}')]
         if hash_tag:
             key = hash_tag
     


### PR DESCRIPTION
Hi, for Redis Enterprise with multiple tags it may be preferable to hash the content of the Right hand tag and not the left hand tag so:

`start_of_key_{dont_hash_this}_{do_hash_this}_end_of_key`